### PR TITLE
Change status code to 201 with POST method

### DIFF
--- a/go/app/main.go
+++ b/go/app/main.go
@@ -33,7 +33,7 @@ func addItem(c echo.Context) error {
 	message := fmt.Sprintf("item received: %s", name)
 	res := Response{Message: message}
 
-	return c.JSON(http.StatusOK, res)
+	return c.JSON(http.StatusCreated, res)
 }
 
 func getImg(c echo.Context) error {


### PR DESCRIPTION
## What
<!--- Write the change being made with this pull request --->
些細な点で失礼します。

go/app/main.go の`addItem`メソッドはPOSTメソッドが呼ばれた際にitemを追加するため、ステータスコードは200より201のほうが適しているように思い、該当箇所を変更しました。

refs: [HTTP レスポンスステータスコード - HTTP | MDN](https://developer.mozilla.org/ja/docs/Web/HTTP/Status#%E6%88%90%E5%8A%9F%E3%83%AC%E3%82%B9%E3%83%9D%E3%83%B3%E3%82%B9), [代表的なHTTPステータスコードと問題解決へのヒント - freee Developers Community](https://developer.freee.co.jp/reference/faq/http-response-code#:~:text=%E4%BB%A3%E8%A1%A8%E7%9A%84%E3%81%AA200%E7%95%AA%E5%8F%B0,%E6%88%90%E5%8A%9F%E6%99%82%E3%81%AB%E5%88%A9%E7%94%A8%E3%81%95%E3%82%8C%E3%81%BE%E3%81%99%E3%80%82)

## CHECKS :warning:

Please make sure you are aware of the following.

- [x] **The changes in this PR doesn't have private information
