### PR TITLE
[step7] fix setItems() properties

### DIFF
--- a/typescript/simple-mercari-web/src/components/ItemList/ItemList.tsx
+++ b/typescript/simple-mercari-web/src/components/ItemList/ItemList.tsx
@@ -31,7 +31,7 @@ export const ItemList: React.FC<Prop> = (props) => {
       .then(response => response.json())
       .then(data => {
         console.log('GET success:', data);
-        setItems(data.items);
+        setItems(data);
         onLoadCompleted && onLoadCompleted();
       })
       .catch(error => {


### PR DESCRIPTION
## What
Fixed to display screen by `npm start`

Currently, if we just run `npm start`, nothing is displayed on the screen.


```
GET success: 
Array(3)
0
{ID: 1, name: 'name', category: 'category', imageFileName: 'image_url'}
1
{ID: 2, name: 'shoes', category: 'mercari', imageFileName: 'edcd3ab5ced7c63e3fc6e10be59452ee6feab674630de3eff3c510bce28f4bff'}
2 
{ID: 3, name: 'super shoes', category: 'mercari', imageFileName: 'edcd3ab5ced7c63e3fc6e10be59452ee6feab674630de3eff3c510bce28f4bff'}
length 3
[[Prototype]]
Array(0)
```
<img width="1267" alt="screenshot_2024-02-26_at_14 04 36" src="https://github.com/mercari-build/mercari-build-training/assets/39621165/dd3dba7a-4e88-4170-bdaa-bb142b2cb619">



## CHECKS :warning:

Please make sure you are aware of the following.

- [x] **The changes in this PR doesn't have private information
