### PR TITLE
update path to dockerfile in ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,11 @@ jobs:
         echo 'Tag: ${{ steps.meta.outputs.tags }}'
         echo 'Label: ${{ steps.meta.labels.tags }}'
 
-#    - name: Build and push Docker image
-#      uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-#      with:
-#       context: <go or python>
-#       push: true
-#       tags: ${{ steps.meta.outputs.tags }}
-#       labels: ${{ steps.meta.outputs.labels }}
+    # - name: Build and push Docker image
+    #   uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+    #   with:
+    #     context: .
+    #     file: <go or python>/dockerfile
+    #     push: true
+    #     tags: ${{ steps.meta.outputs.tags }}
+    #     labels: ${{ steps.meta.outputs.labels }}

--- a/document/08-ci.en.md
+++ b/document/08-ci.en.md
@@ -35,6 +35,10 @@ The file `.github/workflows/build.yml` already contains a workflow that pushes y
 ```
 
 Remove the comment out from the Step and push the docker image via CI.
+```yaml
+file: <go or python>/dockerfile
+```
+This part specifies the path to the dockerfile you are using. Please choose from go and python to specify the correct path.
 
 If the Workflow is successful, the generated image will be pushed to the URL: `ghcr.io/<github-id>/mercari-build-training:<branch-name>`. 
 Pull the image locally and run it.

--- a/document/08-ci.ja.md
+++ b/document/08-ci.ja.md
@@ -33,6 +33,10 @@ GitHubはGitHub Actionsと呼ばれるCIサービスを提供しています。
 #    - name: Build and push Docker image
 ```
 のStepのコメントアウトを外し、CI経由でdocker imageをpushさせてみましょう。
+```yaml
+file: <go or python>/dockerfile
+```
+は、使用するdockerfileへのパスを指定するために、goかpythonの使用している方を記入してください。
 
 うまくいくと `ghcr.io/<github-id>/mercari-build-training:<branch-name>` 
 というURLにimageがpushされるので、ローカルでそのimageをpullして実行してみましょう。


### PR DESCRIPTION
## What
<!--- Write the change being made with this pull request --->
1. STEP 7 dockerfile

> 出品 API を動かすためには、go や　python のプログラムに加えて db のファイルも docker image の中に含める必要があります。 そのためには mercari-build-training/ 以下で docker コマンドを実行する必要があることに注意しましょう。


に合わせ、CIでもmercari-build-training/以下でdocker コマンドを実行するようにパスを変更

2. コメントインした時にインデントエラーが出たため修正
## CHECKS :warning:

Please make sure you are aware of the following.

- [ ] **The changes in this PR doesn't have private information
