### PR TITLE
Fix docker compose commands

### DIFF
--- a/document/07-docker.en.md
+++ b/document/07-docker.en.md
@@ -87,7 +87,7 @@ Check that you can now see `mercari-build-training/app` in the list of images.
 
 * [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)
 
-## 5. Modity Dockerfile
+## 5. Modify Dockerfile
 **Run the docker image you built in STEP7-4, and check if the following error shows up.**
 
 ```

--- a/document/09-frontend.en.md
+++ b/document/09-frontend.en.md
@@ -131,4 +131,4 @@ When selecting a framework, it is good to consider the following perspectives:
 
 ## Next
 
-[STEP10: Run frontend and API using docker-compose](./10-docker-compose.en.md)
+[STEP10: Run frontend and API using Docker Compose](./10-docker-compose.en.md)

--- a/document/09-frontend.ja.md
+++ b/document/09-frontend.ja.md
@@ -131,4 +131,4 @@ export const ItemList = (props: Prop) => {
 
 ## Next
 
-[STEP10: docker-compose で API とフロントエンドを動かす](./10-docker-compose.ja.md)
+[STEP10: Docker Compose で API とフロントエンドを動かす](./10-docker-compose.ja.md)

--- a/document/10-docker-compose.en.md
+++ b/document/10-docker-compose.en.md
@@ -1,4 +1,4 @@
-# STEP10: Run frontend and API using docker-compose
+# STEP10: Run frontend and API using Docker Compose
 In this step, we will learn how to use docker-compose.
 
 **:book: Reference**
@@ -23,7 +23,7 @@ Run the following and check if you can successfully open [http://localhost:3000/
 
 
 ## 2. Installing Docker Compose
-**Install Docker Compose and check you can run `docker-compose -v`**
+**Install Docker Compose and check you can run `docker compose -v`**
 
 **:book: Reference**
 
@@ -38,9 +38,9 @@ Run the following and check if you can successfully open [http://localhost:3000/
 
 Let's check if you can answer the following questions.
 
-* How many services are defined in the docker-compose file in the tutorial? What exactly do these services do?
-* web service and redis services get docker images with different methods. When running `docker-compose up`, check how where each image id downloaded.
-* In docker-compose, you can connect to different services from a service. How does the web service resolve the name for the redis service and connect to it?
+* How many services are defined in the `docker-compose.yaml` file in the tutorial? What exactly do these services do?
+* web service and redis services get docker images with different methods. When running `docker compose up`, check how where each image id downloaded.
+* In Docker Compose, you can connect to different services from a service. How does the web service resolve the name for the redis service and connect to it?
 
 ## 4. Run frontend and API using Docker Compose
 **Referring to the tutorial material, run the frontend and API using Docker Compose**
@@ -62,7 +62,7 @@ Make a new file `docker-compose.yml` considering the following points.
     * Set an environment variable `FRONT_URL` for frontend URL
 
 
-Run `docker-compose up` and check if the following operates properly
+Run `docker compose up` and check if the following operates properly
 - [http://localhost:3000/](http://localhost:3000/) displays the frontend page
-- You can add an new item (Listing)
+- You can add a new item (Listing)
 - You can view the list of all items (ItemList)

--- a/document/10-docker-compose.ja.md
+++ b/document/10-docker-compose.ja.md
@@ -1,6 +1,6 @@
-# STEP10: docker-composeを利用して複数のサービスを動かす
+# STEP10: Docker Composeを利用して複数のサービスを動かす
 
-このステップでは docker-compose の使い方を学びます。
+このステップでは Docker Compose の使い方を学びます。
 
 **:book: Reference**
 
@@ -22,7 +22,7 @@
 を実行し、ブラウザから[http://localhost:3000/](http://localhost:3000/)が正しく開ければ成功です。
 
 ## 2. Docker Compose をインストールする
-**Docker Composeをインストールし、`docker-compose -v` が実行できることを確認しましょう**
+**Docker Composeをインストールし、`docker compose -v` が実行できることを確認しましょう**
 
 **:book: Reference**
 
@@ -37,9 +37,9 @@
 
 以下の質問に答えられるか確認しましょう。
 
-* チュートリアルのdocker-composeファイルにはいくつのサービスが定義されていますか？それらはどのようなサービスですか？
-* webサービスとredisサービスは異なる方法で image を取得しています。`docker-compose up`を実行した際に、各imageはどこから取得されているか確認しましょう。
-* docker-composeでは、サービスから他のサービスのコンテナに接続することができます。webサービスは、redisサービスとどのように名前解決をし、接続していますか？
+* チュートリアルのdocker composeファイルにはいくつのサービスが定義されていますか？それらはどのようなサービスですか？
+* webサービスとredisサービスは異なる方法で image を取得しています。`docker compose up`を実行した際に、各imageはどこから取得されているか確認しましょう。
+* docker composeでは、サービスから他のサービスのコンテナに接続することができます。webサービスは、redisサービスとどのように名前解決をし、接続していますか？
 
 ## 4. Docker ComposeでAPIとフロントエンドを動かす
 **チュートリアルを参考にしながら、今回作成したサービスのフロントエンドとバックエンドのAPIをDocker Composeで動かせるようにしましょう**
@@ -59,7 +59,7 @@
     * APIはフロントエンドにリクエストは送りませんが[CORS](https://developer.mozilla.org/ja/docs/Web/HTTP/CORS)という仕組みのために、どこからリクエストが来るのか知っておく必要があります
     `FRONT_URL`という環境変数でフロントエンドのURLを指定しています
 
-`docker-compose up` でサービスを起動して以下のことができれば成功です。
+`docker compose up` でサービスを起動して以下のことができれば成功です。
 - [http://localhost:3000/](http://localhost:3000/)でページが正しく表示される
 - 新しい商品の登録 (Listing)
 - 商品の一覧の閲覧 (ItemList)


### PR DESCRIPTION
## What

Use updated commands for docker compose, since `docker-compose` is [now deprecated](https://docs.docker.com/compose/releases/migrate/).

## CHECKS :warning:

Please make sure you are aware of the following.

- [x] **The changes in this PR doesn't have private information
